### PR TITLE
fix: 이미지 다중 업로드 수정

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ import cors from "cors";
 import groupsRoute from "./routes/groupsRoute.js";
 import tagsRoute from "./routes/tagsRoute.js";
 import multer from "multer";
+import { asyncHandler } from "./asyncHandler.js";
 
 dotenv.config();
 
@@ -11,15 +12,38 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 
-const upload = multer({ dest: "./uploads" });
-app.use("/images", express.static("uploads"));
-
-app.post("/images", upload.single("files"), (req, res) => {
-  const urls = [
-    `http://localhost:${process.env.PORT}/images/${req.file.filename}`,
-  ];
-  res.json({ urls });
+const upload = multer({
+  dest: "./uploads",
+  fileFilter: (req, file, cb) => {
+    if (!file.mimetype.startsWith("image/")) {
+      return cb(new Error("File should be an image file"));
+    }
+    cb(null, true);
+  },
 });
+
+app.post(
+  "/images",
+  (req, res, next) => {
+    upload.array("files", 10)(req, res, (err) => {
+      if (err) {
+        return res.status(400).json({ error: err.message });
+      }
+      next();
+    });
+  },
+  asyncHandler(async (req, res) => {
+    if (!req.files || req.files.length === 0) {
+      return res.status(400).json({ error: "File error" });
+    }
+
+    const urls = req.files.map(
+      (file) => `http://localhost:${process.env.PORT}/images/${file.filename}`
+    );
+
+    res.json({ urls });
+  })
+);
 
 app.use("/groups", groupsRoute);
 app.use("/tags", tagsRoute);


### PR DESCRIPTION
## 요구사항
#91

### 기본
- [x] 이미지 다중 업로드 시 에러 처리 수정

### 심화

## 주요 변경사항
- 이미지가 기존에는 하나만 업로드가 가능하고, 여러 장 첨부할 경우 발생하는 오류를 수정했습니다.
- 이미지가 아닌 파일은 첨부가 불가합니다.

## 스크린샷
<img width="752" alt="스크린샷 2025-03-17 13 51 08" src="https://github.com/user-attachments/assets/a8304176-bc6e-4afd-9aef-1258a6d026bd" />

## 팀원에게
- postman 에서 테스트해보시면 됩니다.
- multipart/form-data 로 설정하시고 key 이름은 files 입니다.
